### PR TITLE
Add Flathub badge to download section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -195,7 +195,13 @@
                       </div>
                   </div>
 
-                 
+                  <div class="flathub-badge">
+                      <a href="https://flathub.org/en/apps/io.github.mfat.sshpilot" target="_blank" rel="noopener">
+                          <img width="240" alt="Get it on Flathub" src="https://flathub.org/api/badge?locale=en">
+                      </a>
+                  </div>
+
+
              </section>
         </main>
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -510,6 +510,11 @@ footer p {
     margin-right: auto;
 }
 
+.flathub-badge {
+    margin-top: 24px;
+    text-align: center;
+}
+
 .download-platform-btn {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- add a Flathub badge link to the download section of the website
- center the new badge with lightweight styling

## Testing
- not run (static assets change)


------
https://chatgpt.com/codex/tasks/task_e_68d05663546c83289c1831b5af5fc495