### PR TITLE
Add dedicated reviews page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -52,7 +52,7 @@
                  <a href="#about">About</a> |
                  <a href="#features">Features</a> |
                  <a href="#blog">Blog</a> |
-                 <a href="#reviews">Reviews</a> |
+                 <a href="reviews.html">Reviews</a> |
                  <a href="#screenshots">Screenshots</a> |
                  <a href="#download">Download</a> |
                  <a href="https://github.com/mfat/sshpilot" target="_blank">GitHub</a>
@@ -67,7 +67,7 @@
                      <a href="#about">About</a>
                      <a href="#features">Features</a>
                      <a href="#blog">Blog</a>
-                     <a href="#reviews">Reviews</a>
+                     <a href="reviews.html">Reviews</a>
                      <a href="#screenshots">Screenshots</a>
                      <a href="#download">Download</a>
                      <a href="https://github.com/mfat/sshpilot" target="_blank">GitHub</a>
@@ -121,11 +121,7 @@
             <section id="reviews">
                 <h2>Reviews</h2>
                 <p>See what the community is saying about sshPilot.</p>
-                <div class="review-card">
-                    <h3>Linux und Ich</h3>
-                    <p class="review-summary">“sshPilot is a modern alternative to PuTTY and SecureCRT with built-in terminals and smart management tools.”</p>
-                    <a class="review-link" href="https://linuxundich.de/gnu-linux/sshpilot-linux-alternative-putty-securecrt/" target="_blank" rel="noopener">Read the full review</a>
-                </div>
+                <p><a class="review-link" href="reviews.html">Explore press coverage and community reviews.</a></p>
             </section>
 
             <section id="screenshots">

--- a/docs/reviews.html
+++ b/docs/reviews.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>sshPilot Reviews and Press Coverage</title>
+    <meta name="description" content="Discover what the community and tech press are saying about sshPilot, the user-friendly SSH connection manager.">
+    <link rel="stylesheet" href="styles.css">
+    <link rel="icon" type="image/svg+xml" href="io.github.mfat.sshpilot.svg">
+</head>
+<body>
+    <div class="page">
+        <header>
+            <div class="header-content">
+                <img src="io.github.mfat.sshpilot.svg" alt="sshPilot Logo" class="header-icon">
+                <h1>sshPilot</h1>
+            </div>
+            <p>User-friendly, modern SSH Connection Manager</p>
+        </header>
+
+        <nav>
+            <div class="nav-desktop">
+                <a href="index.html#about">About</a> |
+                <a href="index.html#features">Features</a> |
+                <a href="index.html#blog">Blog</a> |
+                <a href="reviews.html">Reviews</a> |
+                <a href="index.html#screenshots">Screenshots</a> |
+                <a href="index.html#download">Download</a> |
+                <a href="https://github.com/mfat/sshpilot" target="_blank">GitHub</a>
+            </div>
+            <div class="nav-mobile">
+                <button class="hamburger" id="hamburger">
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                </button>
+                <div class="nav-menu" id="nav-menu">
+                    <a href="index.html#about">About</a>
+                    <a href="index.html#features">Features</a>
+                    <a href="index.html#blog">Blog</a>
+                    <a href="reviews.html">Reviews</a>
+                    <a href="index.html#screenshots">Screenshots</a>
+                    <a href="index.html#download">Download</a>
+                    <a href="https://github.com/mfat/sshpilot" target="_blank">GitHub</a>
+                </div>
+            </div>
+        </nav>
+
+        <main>
+            <section id="reviews">
+                <h2>Reviews</h2>
+                <p>Industry writers and community members are sharing why sshPilot is becoming their go-to SSH connection manager.</p>
+
+                <div class="review-card">
+                    <h3>Korben</h3>
+                    <p class="review-summary">French tech blogger Korben highlights sshPilot&#39;s intuitive workflow for managing Linux connections and praises its integrated terminal experience.</p>
+                    <a class="review-link" href="https://korben.info/ssh-pilot-gestionnaire-connexions-linux.html" target="_blank" rel="noopener">Read the Korben article</a>
+                </div>
+
+                <div class="review-card">
+                    <h3>Linux und Ich</h3>
+                    <p class="review-summary">Linux und Ich presents sshPilot as a modern alternative to PuTTY and SecureCRT, emphasizing the streamlined interface and smart management tools.</p>
+                    <a class="review-link" href="https://linuxundich.de/gnu-linux/sshpilot-linux-alternative-putty-securecrt/" target="_blank" rel="noopener">Read the Linux und Ich review</a>
+                </div>
+            </section>
+        </main>
+
+        <footer>
+            <div class="footer-links">
+                <a href="https://github.com/mfat/sshpilot/wiki" target="_blank">Online Help</a> |
+                <a href="https://github.com/mfat/sshpilot/issues" target="_blank">Issues</a> |
+                <a href="https://github.com/mfat/sshpilot/discussions" target="_blank">Community</a>
+            </div>
+            <div class="github-stats">
+                <a href="https://github.com/mfat/sshpilot" target="_blank" class="github-link">
+                    <svg class="github-icon" viewBox="0 0 24 24" width="16" height="16">
+                        <path fill="currentColor" d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+                    </svg>
+                    <span class="github-text">Star on GitHub</span>
+                    <span id="github-stars" class="github-stars">⭐</span>
+                </a>
+            </div>
+            <p><a href="https://www.gnu.org/licenses/gpl-3.0.html" target="_blank">Free software (GPL v3 license)</a></p>
+
+            <div class="support-section">
+                <h4>Support the Project</h4>
+                <div class="crypto-addresses">
+                    <div class="crypto-item">
+                        <span class="crypto-icon">₿</span>
+                        <div class="crypto-info">
+                            <span class="crypto-name">Bitcoin</span>
+                            <span class="crypto-address">bc1qqtsyf0ft85zshsnw25jgsxnqy45rfa867zqk4t</span>
+                        </div>
+                    </div>
+                    <div class="crypto-item">
+                        <span class="crypto-icon">Ð</span>
+                        <div class="crypto-info">
+                            <span class="crypto-name">Dogecoin</span>
+                            <span class="crypto-address">DRzNb8DycFD65H6oHNLuzyTzY1S5avPHHx</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </footer>
+    </div>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const hamburger = document.getElementById('hamburger');
+        const navMenu = document.getElementById('nav-menu');
+
+        hamburger.addEventListener('click', function() {
+            hamburger.classList.toggle('active');
+            navMenu.classList.toggle('active');
+        });
+
+        const navLinks = navMenu.querySelectorAll('a');
+        navLinks.forEach(link => {
+            link.addEventListener('click', function() {
+                hamburger.classList.remove('active');
+                navMenu.classList.remove('active');
+            });
+        });
+    });
+
+    (async () => {
+        const repo = "mfat/sshpilot";
+        try {
+            const r = await fetch(`https://api.github.com/repos/${repo}`);
+            const data = await r.json();
+            const starsCount = data.stargazers_count;
+
+            const starsElement = document.getElementById("github-stars");
+            if (starsElement) {
+                starsElement.textContent = `⭐ ${starsCount.toLocaleString()}`;
+            }
+        } catch (error) {
+            console.error('Failed to fetch GitHub stars:', error);
+        }
+    })();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated reviews page that highlights coverage from Korben and Linux und Ich
- update the site navigation to link to the new page and point the homepage reviews section to it

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d3bb0f3a3c8328999f9ac588054789