### PR TITLE
Add Flatpak download button to download grid

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -181,6 +181,13 @@
                                   <span class="platform-format">AUR</span>
                               </div>
                           </a>
+                          <a href="https://flathub.org/en/apps/io.github.mfat.sshpilot" target="_blank" rel="noopener" class="download-platform-btn flatpak-btn">
+                              <img src="logos/flathub.svg" alt="Flatpak" class="platform-logo">
+                              <div class="platform-info">
+                                  <span class="platform-name">Flatpak</span>
+                                  <span class="platform-format">Flathub</span>
+                              </div>
+                          </a>
                           <a id="dl-mac" href="#" class="download-platform-btn mac-btn">
                               <img src="logos/apple.svg" alt="macOS" class="platform-logo">
                               <div class="platform-info">
@@ -189,12 +196,6 @@
                               </div>
                           </a>
                       </div>
-                  </div>
-
-                  <div class="flathub-badge">
-                      <a href="https://flathub.org/en/apps/io.github.mfat.sshpilot" target="_blank" rel="noopener">
-                          <img width="240" alt="Get it on Flathub" src="https://flathub.org/api/badge?locale=en">
-                      </a>
                   </div>
 
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -510,11 +510,6 @@ footer p {
     margin-right: auto;
 }
 
-.flathub-badge {
-    margin-top: 24px;
-    text-align: center;
-}
-
 .download-platform-btn {
     display: flex;
     align-items: center;
@@ -604,6 +599,11 @@ footer p {
 .mac-btn:hover {
     border-color: #000;
     background: linear-gradient(135deg, #fff 0%, #f8f8f8 100%);
+}
+
+.flatpak-btn:hover {
+    border-color: #4A86CF;
+    background: linear-gradient(135deg, #fff 0%, #f5f9ff 100%);
 }
 
 /* Responsive */


### PR DESCRIPTION
## Summary
- add a Flatpak download button that uses the new logo alongside the other platform buttons
- remove the standalone Flathub badge and give the new button hover styling consistent with the rest of the grid

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7ba3a9560832899dcdf003b081b83