### PR TITLE
Reorganize homepage content

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -49,12 +49,11 @@
 
          <nav>
              <div class="nav-desktop">
-                 <a href="#about">About</a> |
-                 <a href="#features">Features</a> |
-                 <a href="#blog">Blog</a> |
-                 <a href="reviews.html">Reviews</a> |
                  <a href="#screenshots">Screenshots</a> |
                  <a href="#download">Download</a> |
+                 <a href="#about">About</a> |
+                 <a href="#features">Features</a> |
+                 <a href="reviews.html">Reviews</a> |
                  <a href="https://github.com/mfat/sshpilot" target="_blank">GitHub</a>
              </div>
              <div class="nav-mobile">
@@ -64,12 +63,11 @@
                      <span></span>
                  </button>
                  <div class="nav-menu" id="nav-menu">
-                     <a href="#about">About</a>
-                     <a href="#features">Features</a>
-                     <a href="#blog">Blog</a>
-                     <a href="reviews.html">Reviews</a>
                      <a href="#screenshots">Screenshots</a>
                      <a href="#download">Download</a>
+                     <a href="#about">About</a>
+                     <a href="#features">Features</a>
+                     <a href="reviews.html">Reviews</a>
                      <a href="https://github.com/mfat/sshpilot" target="_blank">GitHub</a>
                  </div>
              </div>
@@ -78,52 +76,6 @@
                 
 
         <main>
-            <section id="about">
-                <h2>About</h2>
-                <p>sshPilot is a user-friendly, lightweight SSH connection manager with an integrated terminal.</p>
-                <p>No more remembering host aliases or complex SSH commands to manage your machines, copy keys or set up port forwarding.</p>
-            </section>
-
-
-            <section id="features">
-                <h2>Features</h2>
-                <ul>
-                    <li><strong>Tabbed Interface</strong> - Manage multiple SSH connections with tabs</li>
-                    <li><strong>Compatible</strong> - Loads your existing SSH configuration</li>
-                    <li><strong>Keyboard Navigation</strong> - Full keyboard support with shortcuts, quickly switch between hosts</li>
-                    <li><strong>Server Grouping</strong> - Organize your servers into folders</li>
-                    <li><strong>File Management</strong> - Manage files and directories with SFTP</li>
-                    <li><strong>Secure Storage</strong> - Secure storage for passwords and private key passphrases</li>
-                    <li><strong>Port Forwarding</strong> - Local, Remote and Dynamic port forwarding</li>
-                    <li><strong>Easy Key Generation and Transfer</strong> - Generate keypairs and copy them to your servers</li>
-                    <li><strong>Customizable UI</strong> - Light/Dark themes and terminal customization</li>
-                    <li><strong>Performance</strong> - Lightweight and fast</li>
-                </ul>
-            </section>
-
-            <section id="blog">
-                <h2>Blog</h2>
-                <p>Stay informed about sshPilot development and get tips for managing your infrastructure more efficiently.</p>
-                <div class="blog-list">
-                    <article class="blog-post">
-                        <h3>Introducing sshPilot</h3>
-                        <p class="blog-meta">A quick tour of the core features and what sets sshPilot apart.</p>
-                        <a class="blog-link" href="https://github.com/mfat/sshpilot/wiki" target="_blank" rel="noopener">Read more in the project wiki</a>
-                    </article>
-                    <article class="blog-post">
-                        <h3>Productivity Tips</h3>
-                        <p class="blog-meta">Discover keyboard shortcuts, grouping strategies, and automation ideas to accelerate your SSH workflow.</p>
-                        <a class="blog-link" href="https://github.com/mfat/sshpilot/discussions" target="_blank" rel="noopener">Join the community discussions</a>
-                    </article>
-                </div>
-            </section>
-
-            <section id="reviews">
-                <h2>Reviews</h2>
-                <p>See what the community is saying about sshPilot.</p>
-                <p><a class="review-link" href="reviews.html">Explore press coverage and community reviews.</a></p>
-            </section>
-
             <section id="screenshots">
                 <h2>Screenshots</h2>
                 <div class="screenshots">
@@ -154,52 +106,73 @@
                 </div>
             </section>
 
-             <section id="download">
-                 <h2>Download</h2>
-                 <h3>Latest Release</h3>
-                 <p>sshPilot is currently available for GNU/Linux and macOS. Download the latest stable version for your platform</p>
-                  <div>
-                      <div class="download-buttons">
-                          <a id="dl-deb" href="#" class="download-platform-btn debian-btn">
-                              <img src="logos/debian.svg" alt="Debian" class="platform-logo">
-                              <div class="platform-info">
-                                  <span class="platform-name">Debian/Ubuntu</span>
-                                  <span class="platform-format">.deb</span>
-                              </div>
-                          </a>
-                          <a id="dl-rpm" href="#" class="download-platform-btn fedora-btn">
-                              <img src="logos/fedora.svg" alt="Fedora" class="platform-logo">
-                              <div class="platform-info">
-                                  <span class="platform-name">Fedora/RHEL</span>
-                                  <span class="platform-format">.rpm</span>
-                              </div>
-                          </a>
-                          <a href="https://aur.archlinux.org/packages/sshpilot" target="_blank" class="download-platform-btn arch-btn">
-                              <img src="logos/arch.svg" alt="Arch Linux" class="platform-logo">
-                              <div class="platform-info">
-                                  <span class="platform-name">Arch Linux</span>
-                                  <span class="platform-format">AUR</span>
-                              </div>
-                          </a>
-                          <a href="https://flathub.org/en/apps/io.github.mfat.sshpilot" target="_blank" rel="noopener" class="download-platform-btn flatpak-btn">
-                              <img src="logos/flathub.svg" alt="Flatpak" class="platform-logo">
-                              <div class="platform-info">
-                                  <span class="platform-name">Flatpak</span>
-                                  <span class="platform-format">Flathub</span>
-                              </div>
-                          </a>
-                          <a id="dl-mac" href="#" class="download-platform-btn mac-btn">
-                              <img src="logos/apple.svg" alt="macOS" class="platform-logo">
-                              <div class="platform-info">
-                                  <span class="platform-name">macOS</span>
-                                  <span class="platform-format">.dmg</span>
-                              </div>
-                          </a>
-                      </div>
-                  </div>
+            <section id="download">
+                <h2>Download</h2>
+                <h3>Latest Release</h3>
+                <p>sshPilot is currently available for GNU/Linux and macOS. Download the latest stable version for your platform</p>
+                <div>
+                    <div class="download-buttons">
+                        <a id="dl-deb" href="#" class="download-platform-btn debian-btn">
+                            <img src="logos/debian.svg" alt="Debian" class="platform-logo">
+                            <div class="platform-info">
+                                <span class="platform-name">Debian/Ubuntu</span>
+                                <span class="platform-format">.deb</span>
+                            </div>
+                        </a>
+                        <a id="dl-rpm" href="#" class="download-platform-btn fedora-btn">
+                            <img src="logos/fedora.svg" alt="Fedora" class="platform-logo">
+                            <div class="platform-info">
+                                <span class="platform-name">Fedora/RHEL</span>
+                                <span class="platform-format">.rpm</span>
+                            </div>
+                        </a>
+                        <a href="https://aur.archlinux.org/packages/sshpilot" target="_blank" class="download-platform-btn arch-btn">
+                            <img src="logos/arch.svg" alt="Arch Linux" class="platform-logo">
+                            <div class="platform-info">
+                                <span class="platform-name">Arch Linux</span>
+                                <span class="platform-format">AUR</span>
+                            </div>
+                        </a>
+                        <a href="https://flathub.org/en/apps/io.github.mfat.sshpilot" target="_blank" rel="noopener" class="download-platform-btn flatpak-btn">
+                            <img src="logos/flathub.svg" alt="Flatpak" class="platform-logo">
+                            <div class="platform-info">
+                                <span class="platform-name">Flatpak</span>
+                                <span class="platform-format">Flathub</span>
+                            </div>
+                        </a>
+                        <a id="dl-mac" href="#" class="download-platform-btn mac-btn">
+                            <img src="logos/apple.svg" alt="macOS" class="platform-logo">
+                            <div class="platform-info">
+                                <span class="platform-name">macOS</span>
+                                <span class="platform-format">.dmg</span>
+                            </div>
+                        </a>
+                    </div>
+                </div>
+            </section>
+
+            <section id="about">
+                <h2>About</h2>
+                <p>sshPilot is a user-friendly, lightweight SSH connection manager with an integrated terminal.</p>
+                <p>No more remembering host aliases or complex SSH commands to manage your machines, copy keys or set up port forwarding.</p>
+            </section>
 
 
-             </section>
+            <section id="features">
+                <h2>Features</h2>
+                <ul>
+                    <li><strong>Tabbed Interface</strong> - Manage multiple SSH connections with tabs</li>
+                    <li><strong>Compatible</strong> - Loads your existing SSH configuration</li>
+                    <li><strong>Keyboard Navigation</strong> - Full keyboard support with shortcuts, quickly switch between hosts</li>
+                    <li><strong>Server Grouping</strong> - Organize your servers into folders</li>
+                    <li><strong>File Management</strong> - Manage files and directories with SFTP</li>
+                    <li><strong>Secure Storage</strong> - Secure storage for passwords and private key passphrases</li>
+                    <li><strong>Port Forwarding</strong> - Local, Remote and Dynamic port forwarding</li>
+                    <li><strong>Easy Key Generation and Transfer</strong> - Generate keypairs and copy them to your servers</li>
+                    <li><strong>Customizable UI</strong> - Light/Dark themes and terminal customization</li>
+                    <li><strong>Performance</strong> - Lightweight and fast</li>
+                </ul>
+            </section>
         </main>
 
          <footer>


### PR DESCRIPTION
## Summary
- remove the blog section and home-page reviews block
- move the screenshots and download sections to the top of the landing page
- update navigation links to match the new section order

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7bbf79c6483288f81bab41c2c8d7f