### PR TITLE
Refine screenshot gallery layout

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,7 @@
     <title>SSH Pilot - User-friendly SSH Connection Manager</title>
     <meta name="description" content="SSH Pilot is a user-friendly, modern and lightweight SSH connection manager, with an integrated terminal. An alternative to Putty and Termius.">
     <link rel="stylesheet" href="styles.css">
+    <script src="screenshots.js" defer></script>
     <link rel="icon" type="image/svg+xml" href="io.github.mfat.sshpilot.svg">
     <style>
         .download-btn {
@@ -87,30 +88,32 @@
             <section id="screenshots">
                 <h2>Screenshots</h2>
                 <div class="screenshots">
-                    <figure>
-                        <img src="screenshots/start-page.png" alt="Main Window">
-                        <figcaption>Start Page</figcaption>
-                    </figure>
-                    <figure>
-                        <img src="screenshots/main-window.png" alt="Connection Settings">
-                        <figcaption>Man window with terminal</figcaption>
-                    </figure>
-                    <figure>
-                        <img src="screenshots/ssh-copy-id.png" alt="Terminal Settings">
-                        <figcaption>Key Deployment</figcaption>
-                    </figure>
-                    <figure>
-                        <img src="screenshots/tab-overview.png" alt="Preferences">
-                        <figcaption>Tab Overview</figcaption>
-                    </figure>
-                    <figure>
-                        <img src="screenshots/commands.png" alt="Terminal with htop">
-                        <figcaption>Commands</figcaption>
-                    </figure>
-                    <figure>
-                        <img src="screenshots/main-window-light.png" alt="Advanced Configuration">
-                        <figcaption>Main Window in Light Mode</figcaption>
-                    </figure>
+                    <div class="screenshots-gallery">
+                        <figure class="screenshot-frame">
+                            <img src="screenshots/start-page.png" alt="Main Window" loading="lazy">
+                            <figcaption>Start Page</figcaption>
+                        </figure>
+                        <figure class="screenshot-frame">
+                            <img src="screenshots/main-window.png" alt="Connection Settings" loading="lazy">
+                            <figcaption>Main window with terminal</figcaption>
+                        </figure>
+                        <figure class="screenshot-frame">
+                            <img src="screenshots/ssh-copy-id.png" alt="Terminal Settings" loading="lazy">
+                            <figcaption>Key Deployment</figcaption>
+                        </figure>
+                        <figure class="screenshot-frame">
+                            <img src="screenshots/tab-overview.png" alt="Preferences" loading="lazy">
+                            <figcaption>Tab Overview</figcaption>
+                        </figure>
+                        <figure class="screenshot-frame">
+                            <img src="screenshots/commands.png" alt="Terminal with htop" loading="lazy">
+                            <figcaption>Commands</figcaption>
+                        </figure>
+                        <figure class="screenshot-frame">
+                            <img src="screenshots/main-window-light.png" alt="Advanced Configuration" loading="lazy">
+                            <figcaption>Main Window in Light Mode</figcaption>
+                        </figure>
+                    </div>
                 </div>
             </section>
 

--- a/docs/screenshots.js
+++ b/docs/screenshots.js
@@ -1,0 +1,95 @@
+(function () {
+    const scheduleMasonryUpdate = (function () {
+        let rafId = null;
+        return (callback) => {
+            if (rafId !== null) return;
+            rafId = requestAnimationFrame(() => {
+                rafId = null;
+                callback();
+            });
+        };
+    })();
+
+    function initialiseMasonry(gallery) {
+        if (!gallery) return;
+        const items = () => Array.from(gallery.querySelectorAll('.screenshot-frame'));
+
+        const getMaxSpan = (rowHeight, rowGap) => {
+            const maxHeight = parseFloat(getComputedStyle(gallery).getPropertyValue('--masonry-max-height'));
+            if (!maxHeight) {
+                return Infinity;
+            }
+            return Math.max(1, Math.round((maxHeight + rowGap) / (rowHeight + rowGap)));
+        };
+
+        const clampImageHeight = (item) => {
+            const img = item.querySelector('img');
+            if (!img) return;
+            const styles = getComputedStyle(gallery);
+            const maxHeight = parseFloat(styles.getPropertyValue('--masonry-max-height'));
+            if (!maxHeight) {
+                img.style.removeProperty('max-height');
+                return;
+            }
+            img.style.maxHeight = `${maxHeight}px`;
+        };
+
+        const computeSpan = (item) => {
+            if (!item) return;
+            item.style.removeProperty('grid-row-end');
+            const styles = getComputedStyle(gallery);
+            const rowHeight = parseFloat(styles.getPropertyValue('--masonry-row-height')) || 8;
+            const rowGap = parseFloat(styles.rowGap || styles.getPropertyValue('row-gap')) || 0;
+            const maxSpan = getMaxSpan(rowHeight, rowGap);
+            clampImageHeight(item);
+            const itemHeight = item.getBoundingClientRect().height;
+            if (!itemHeight) return;
+            const span = Math.max(1, Math.round((itemHeight + rowGap) / (rowHeight + rowGap)));
+            item.style.gridRowEnd = `span ${Math.min(span, maxSpan)}`;
+        };
+
+        const updateAll = () => {
+            scheduleMasonryUpdate(() => {
+                items().forEach(computeSpan);
+            });
+        };
+
+        const observeImages = () => {
+            items().forEach((item) => {
+                const img = item.querySelector('img');
+                if (!img) return;
+                if (img.complete && img.naturalHeight !== 0) {
+                    computeSpan(item);
+                    return;
+                }
+                img.addEventListener('load', () => computeSpan(item), { once: true });
+                img.addEventListener('error', () => computeSpan(item), { once: true });
+            });
+        };
+
+        observeImages();
+        updateAll();
+
+        window.addEventListener('resize', updateAll);
+
+        if (typeof ResizeObserver !== 'undefined') {
+            const resizeObserver = new ResizeObserver(updateAll);
+            resizeObserver.observe(gallery);
+        }
+
+        if (typeof MutationObserver !== 'undefined') {
+            const mutationObserver = new MutationObserver(() => {
+                observeImages();
+                updateAll();
+            });
+            mutationObserver.observe(gallery, { childList: true, subtree: true });
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        const gallery = document.querySelector('.screenshots-gallery');
+        if (gallery) {
+            initialiseMasonry(gallery);
+        }
+    });
+})();

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -360,20 +360,111 @@ a:hover {
     margin: 20px 0;
 }
 
-figure {
-    margin: 20px 0;
-    text-align: center;
+
+
+.screenshots-gallery {
+    --masonry-row-height: 8px;
+    --masonry-max-height: 240px;
+    --masonry-gap: 16px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    grid-auto-rows: var(--masonry-row-height);
+    grid-auto-flow: dense;
+    gap: var(--masonry-gap);
+    padding: 22px;
+    border-radius: 22px;
+    border: 1px solid #dfe6f3;
+    background: linear-gradient(150deg, #f8fafc 0%, #eef2f7 100%);
+    box-shadow: 0 22px 42px rgba(15, 23, 42, 0.08);
+    overflow: hidden;
 }
 
-figure img {
-    max-width: 100%;
+.screenshots-gallery figure {
+    margin: 0;
+}
+
+.screenshot-frame {
+    position: relative;
+    overflow: hidden;
+    border-radius: 16px;
+    background: rgba(15, 23, 42, 0.08);
+    grid-row-end: span 1;
+    max-height: var(--masonry-max-height);
+    transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.screenshot-frame::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.22), transparent 55%),
+        radial-gradient(circle at 80% 0%, rgba(148, 163, 184, 0.18), transparent 55%);
+    opacity: 0;
+    transition: opacity 0.18s ease;
+    pointer-events: none;
+}
+
+.screenshot-frame:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 18px 32px rgba(15, 23, 42, 0.16);
+}
+
+.screenshot-frame:hover::after {
+    opacity: 1;
+}
+
+.screenshot-frame img {
+    display: block;
+    width: 100%;
     height: auto;
-    border: 1px solid #ccc;
+    max-height: var(--masonry-max-height);
+    border-radius: 16px;
+    transition: transform 0.25s ease;
+}
+
+.screenshot-frame:hover img {
+    transform: scale(1.02);
+}
+
+.screenshot-frame figcaption {
+    position: absolute;
+    inset: auto 0 0 0;
+    padding: 12px 16px 16px 16px;
+    font-weight: 600;
+    font-size: 0.85em;
+    letter-spacing: 0.01em;
+    color: #f8fafc;
+    text-align: left;
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0), rgba(15, 23, 42, 0.88));
+    pointer-events: none;
+    margin: 0;
 }
 
 figcaption {
     margin-top: 10px;
     font-weight: bold;
+}
+
+@media (max-width: 720px) {
+    .screenshots-gallery {
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        --masonry-row-height: 7px;
+        --masonry-max-height: 220px;
+        --masonry-gap: 14px;
+        padding: 18px;
+        border-radius: 20px;
+    }
+}
+
+@media (max-width: 480px) {
+    .screenshots-gallery {
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        --masonry-row-height: 6px;
+        --masonry-max-height: 200px;
+        --masonry-gap: 12px;
+        padding: 14px;
+        border-radius: 18px;
+    }
 }
 
 /* Footer */


### PR DESCRIPTION
## Summary
- restyle the screenshots section with a responsive masonry grid that sits inside a single wide gallery surface
- load a helper script that recalculates each tile span after images render to keep the mosaic compact across breakpoints
- overlay captions and hover treatments so tall screenshots stay within the low-profile justified gallery

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d7dec1eef4832897b358a7200b5172