### PR TITLE
Handle screenshot gallery frame constraints

### DIFF
--- a/docs/screenshots.js
+++ b/docs/screenshots.js
@@ -26,30 +26,158 @@
         return 1;
     }
 
-    function applyRowLayout(row, innerWidth, targetRowHeight, maxRowHeight, gap, isLastRow) {
-        if (!row.length) return;
-        const aspectSum = row.reduce((sum, item) => sum + item.ratio, 0);
-        if (!aspectSum) return;
-        const gapTotal = gap * Math.max(0, row.length - 1);
-        const widthAtTarget = aspectSum * targetRowHeight;
-        let scale = (innerWidth - gapTotal) / widthAtTarget;
-        const maxScale = maxRowHeight / targetRowHeight;
+    function parseMinWidth(value) {
+        if (!value || value === 'auto' || value === 'none') {
+            return 0;
+        }
+        const parsed = parseFloat(value);
+        return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+    }
+
+    function parseMaxWidth(value) {
+        if (!value || value === 'none') {
+            return Infinity;
+        }
+        const parsed = parseFloat(value);
+        return Number.isFinite(parsed) && parsed > 0 ? parsed : Infinity;
+    }
+
+    function clampWidthForItem(item, rowHeight) {
+        let width = rowHeight * item.ratio;
+        if (item.minWidth > 0) {
+            width = Math.max(width, item.minWidth);
+        }
+        if (Number.isFinite(item.maxWidth)) {
+            width = Math.min(width, item.maxWidth);
+        }
+        return Math.max(0, width);
+    }
+
+    function getRowWidth(row, rowHeight) {
+        return row.reduce((sum, item) => sum + clampWidthForItem(item, rowHeight), 0);
+    }
+
+    function getScaleBounds(row, targetRowHeight, maxRowHeight, isLastRow) {
+        let minScale = 0;
+        let maxScale = maxRowHeight > 0 ? maxRowHeight / targetRowHeight : Infinity;
+
+        if (!Number.isFinite(maxScale) || maxScale <= 0) {
+            maxScale = Infinity;
+        }
+
+        row.forEach((item) => {
+            if (!Number.isFinite(item.ratio) || item.ratio <= 0) {
+                return;
+            }
+
+            if (item.minWidth > 0) {
+                const candidate = item.minWidth / (item.ratio * targetRowHeight);
+                if (Number.isFinite(candidate)) {
+                    minScale = Math.max(minScale, candidate);
+                }
+            }
+
+            if (Number.isFinite(item.maxWidth)) {
+                const candidate = item.maxWidth / (item.ratio * targetRowHeight);
+                if (Number.isFinite(candidate)) {
+                    maxScale = Math.min(maxScale, candidate);
+                }
+            }
+        });
 
         if (isLastRow) {
-            scale = Math.min(scale, 1);
+            maxScale = Math.min(maxScale, 1);
         }
 
-        if (!Number.isFinite(scale) || scale <= 0) {
-            scale = 1;
+        minScale = Math.max(minScale, 0);
+
+        if (!Number.isFinite(maxScale) || maxScale <= 0) {
+            maxScale = minScale > 0 ? minScale : 1;
         }
 
-        scale = Math.min(scale, maxScale);
+        if (maxScale < minScale) {
+            maxScale = minScale;
+        }
+
+        return { minScale, maxScale };
+    }
+
+    function getWidthForScale(row, targetRowHeight, scale) {
+        return getRowWidth(row, targetRowHeight * scale);
+    }
+
+    function resolveRowScale(row, targetRowHeight, maxRowHeight, widthAvailable, isLastRow) {
+        const { minScale, maxScale } = getScaleBounds(row, targetRowHeight, maxRowHeight, isLastRow);
+        const lower = minScale;
+        const upper = maxScale;
+        const widthAtLower = getWidthForScale(row, targetRowHeight, lower);
+        const widthAtUpper = getWidthForScale(row, targetRowHeight, upper);
+
+        if (!Number.isFinite(widthAvailable) || widthAvailable <= 0) {
+            return {
+                scale: lower,
+                minScale: lower,
+                maxScale: upper,
+                widthAtLower,
+                widthAtUpper,
+                reachedLower: true,
+                reachedUpper: false,
+            };
+        }
+
+        let scale = lower;
+        let reachedLower = false;
+        let reachedUpper = false;
+
+        if (widthAvailable <= widthAtLower) {
+            scale = lower;
+            reachedLower = true;
+        } else if (widthAvailable >= widthAtUpper) {
+            scale = upper;
+            reachedUpper = true;
+        } else {
+            let lo = lower;
+            let hi = upper;
+
+            for (let i = 0; i < 20; i++) {
+                const mid = (lo + hi) / 2;
+                const width = getWidthForScale(row, targetRowHeight, mid);
+                if (width < widthAvailable) {
+                    lo = mid;
+                } else {
+                    hi = mid;
+                }
+            }
+
+            scale = (lo + hi) / 2;
+        }
+
+        return {
+            scale,
+            minScale: lower,
+            maxScale: upper,
+            widthAtLower,
+            widthAtUpper,
+            reachedLower,
+            reachedUpper,
+        };
+    }
+
+    function applyRowLayout(row, innerWidth, targetRowHeight, maxRowHeight, gap, isLastRow) {
+        if (!row.length) return;
+        const gapTotal = gap * Math.max(0, row.length - 1);
+        const widthAvailable = innerWidth - gapTotal;
+
+        const {
+            scale,
+        } = resolveRowScale(row, targetRowHeight, maxRowHeight, widthAvailable, isLastRow);
+
         const rowHeight = Math.max(1, targetRowHeight * scale);
 
-        row.forEach(({ frame, ratio }) => {
-            const width = rowHeight * ratio;
-            frame.style.width = `${width}px`;
-            frame.style.height = `${rowHeight}px`;
+        row.forEach((item) => {
+            const width = clampWidthForItem(item, rowHeight);
+            item.frame.style.width = `${width}px`;
+            item.frame.style.height = `${rowHeight}px`;
         });
     }
 
@@ -75,34 +203,43 @@
             frame.style.removeProperty('height');
         });
 
-        let row = [];
-        let aspectAccumulator = 0;
-
-        frames.forEach((frame) => {
+        const items = frames.map((frame) => {
             const ratio = getAspectRatio(frame);
             if (!Number.isFinite(ratio) || ratio <= 0) {
-                return;
+                return null;
             }
 
-            row.push({ frame, ratio });
-            aspectAccumulator += ratio;
+            const computed = getComputedStyle(frame);
+            const minWidth = parseMinWidth(computed.minWidth);
+            const maxWidth = parseMaxWidth(computed.maxWidth);
 
-            const expectedWidth = aspectAccumulator * targetRowHeight + gap * Math.max(0, row.length - 1);
+            return { frame, ratio, minWidth, maxWidth };
+        }).filter(Boolean);
+
+        let row = [];
+
+        items.forEach((item) => {
+            row.push(item);
+
+            const expectedWidth = getRowWidth(row, targetRowHeight) + gap * Math.max(0, row.length - 1);
             if (expectedWidth >= innerWidth) {
                 const gapTotal = gap * Math.max(0, row.length - 1);
-                const scale = (innerWidth - gapTotal) / (aspectAccumulator * targetRowHeight);
-                const maxScale = maxRowHeight / targetRowHeight;
+                const widthAvailable = innerWidth - gapTotal;
 
-                if (scale > maxScale && row.length > 1) {
+                const scaleInfo = resolveRowScale(row, targetRowHeight, maxRowHeight, widthAvailable, false);
+
+                const shouldDeferLastItem = row.length > 1 && (
+                    (scaleInfo.reachedUpper && widthAvailable > scaleInfo.widthAtUpper + 0.5) ||
+                    (scaleInfo.reachedLower && widthAvailable < scaleInfo.widthAtLower - 0.5)
+                );
+
+                if (shouldDeferLastItem) {
                     const lastItem = row.pop();
-                    aspectAccumulator -= lastItem.ratio;
                     applyRowLayout(row, innerWidth, targetRowHeight, maxRowHeight, gap, false);
                     row = [lastItem];
-                    aspectAccumulator = lastItem.ratio;
                 } else {
                     applyRowLayout(row, innerWidth, targetRowHeight, maxRowHeight, gap, false);
                     row = [];
-                    aspectAccumulator = 0;
                 }
             }
         });

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -391,7 +391,6 @@ a:hover {
     transition: transform 0.18s ease, box-shadow 0.18s ease;
     flex: 0 0 auto;
     display: block;
-    min-width: 140px;
 
 }
 
@@ -404,6 +403,12 @@ a:hover {
     opacity: 0;
     transition: opacity 0.18s ease;
     pointer-events: none;
+}
+
+@media (min-width: 640px) {
+    .screenshot-frame {
+        min-width: 140px;
+    }
 }
 
 .screenshot-frame:hover {


### PR DESCRIPTION
## Summary
- relax the screenshot frame min-width so the gallery script can size frames freely on small viewports
- teach the gallery layout script to read each frame’s computed min/max width and respect those constraints when distributing row widths

## Testing
- browser_container.run_playwright_script (viewport checks at 420/640/960/1280 px)


------
https://chatgpt.com/codex/tasks/task_e_68d7fa621e788328ae3c97230ef53611