### PR TITLE
Add automated screenshot gallery

### DIFF
--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -15,20 +15,21 @@ cp your-screenshot.png docs/screenshots/
 Run the update script to automatically update the website:
 
 ```bash
-python3 update_screenshots.py
+python3 docs/update_screenshots.py
 ```
 
 This script will:
 - Scan the `docs/screenshots/` directory for PNG files
 - Generate captions based on filenames (e.g., `main-window.png` → `Main Window`)
-- Update the `docs/screenshots.js` file automatically
+- Read optional overrides from `docs/screenshot_captions.json`
+- Update the `docs/screenshot_data.js` file automatically
 
 ### 3. Commit and Deploy
 Commit your changes and push to deploy:
 
 ```bash
 git add docs/screenshots/your-screenshot.png
-git add docs/screenshots.js
+git add docs/screenshot_data.js
 git commit -m "Add new screenshot: your-screenshot.png"
 git push origin main
 ```
@@ -48,15 +49,16 @@ The script automatically generates captions from filenames:
 - `port-forwarding.png` → "Port Forwarding"
 
 ### Manual Caption Override
-If you want custom captions, edit the `screenshotData` object in `docs/screenshots.js`:
+If you want custom captions, edit or create the `docs/screenshot_captions.json` file:
 
-```javascript
-const screenshotData = {
-    'main-window.png': 'Custom caption here',
-    'ssh-settings.png': 'Another custom caption',
-    // ... other screenshots
-};
+```json
+{
+    "main-window.png": "Custom caption here",
+    "ssh-settings.png": "Another custom caption"
+}
 ```
+
+After updating the JSON file, rerun the update script so the gallery picks up the change.
 
 ## Website Features
 
@@ -84,9 +86,12 @@ docs/
 │   ├── main-window.png
 │   ├── ssh-settings.png
 │   └── ...
-├── screenshots.js         # JavaScript for slideshow functionality
+├── screenshot_captions.json  # Optional caption overrides
+├── screenshot_data.js    # Auto-generated gallery data
+├── screenshots.js        # JavaScript that renders the gallery
 ├── styles.css            # CSS styles for screenshots
-└── index.html           # Main website with screenshot section
+├── update_screenshots.py # Script that refreshes the gallery data
+└── index.html            # Main website with screenshot section
 ```
 
 ## Troubleshooting
@@ -94,10 +99,10 @@ docs/
 ### Screenshots Not Appearing
 1. Ensure files are PNG format
 2. Check file permissions
-3. Run `python3 update_screenshots.py` to update the JavaScript
+3. Run `python3 docs/update_screenshots.py` to regenerate the gallery data
 
 ### Captions Not Updating
-1. Edit the `screenshotData` object in `docs/screenshots.js`
+1. Update `docs/screenshot_captions.json`
 2. Or rename the file to match the desired caption
 
 ### Slideshow Not Working

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,7 @@
     <title>SSH Pilot - User-friendly SSH Connection Manager</title>
     <meta name="description" content="SSH Pilot is a user-friendly, modern and lightweight SSH connection manager, with an integrated terminal. An alternative to Putty and Termius.">
     <link rel="stylesheet" href="styles.css">
+    <script src="screenshot_data.js" defer></script>
     <script src="screenshots.js" defer></script>
     <link rel="icon" type="image/svg+xml" href="io.github.mfat.sshpilot.svg">
     <style>
@@ -88,31 +89,8 @@
             <section id="screenshots">
                 <h2>Screenshots</h2>
                 <div class="screenshots">
-                    <div class="screenshots-gallery">
-                        <figure class="screenshot-frame">
-                            <img src="screenshots/start-page.png" alt="Main Window" loading="lazy">
-                            <figcaption>Start Page</figcaption>
-                        </figure>
-                        <figure class="screenshot-frame">
-                            <img src="screenshots/main-window.png" alt="Connection Settings" loading="lazy">
-                            <figcaption>Main window with terminal</figcaption>
-                        </figure>
-                        <figure class="screenshot-frame">
-                            <img src="screenshots/ssh-copy-id.png" alt="Terminal Settings" loading="lazy">
-                            <figcaption>Key Deployment</figcaption>
-                        </figure>
-                        <figure class="screenshot-frame">
-                            <img src="screenshots/tab-overview.png" alt="Preferences" loading="lazy">
-                            <figcaption>Tab Overview</figcaption>
-                        </figure>
-                        <figure class="screenshot-frame">
-                            <img src="screenshots/commands.png" alt="Terminal with htop" loading="lazy">
-                            <figcaption>Commands</figcaption>
-                        </figure>
-                        <figure class="screenshot-frame">
-                            <img src="screenshots/main-window-light.png" alt="Advanced Configuration" loading="lazy">
-                            <figcaption>Main Window in Light Mode</figcaption>
-                        </figure>
+                    <div class="screenshots-gallery" id="screenshots-gallery">
+                        <p class="screenshots-empty-state">Screenshots are on the way.</p>
                     </div>
                 </div>
             </section>

--- a/docs/screenshot_captions.json
+++ b/docs/screenshot_captions.json
@@ -1,0 +1,9 @@
+{
+    "commands.png": "Commands",
+    "main-window-light.png": "Main Window in Light Mode",
+    "main-window.png": "Main Window",
+    "ssh-copy-id.png": "Key Deployment",
+    "start-page.png": "Start Page",
+    "tab-overview.png": "Tab Overview",
+    "terminal-settings.png": "Terminal Settings"
+}

--- a/docs/screenshot_data.js
+++ b/docs/screenshot_data.js
@@ -1,0 +1,30 @@
+window.screenshotData = [
+    {
+        "file": "commands.png",
+        "caption": "Commands"
+    },
+    {
+        "file": "main-window-light.png",
+        "caption": "Main Window in Light Mode"
+    },
+    {
+        "file": "main-window.png",
+        "caption": "Main Window"
+    },
+    {
+        "file": "ssh-copy-id.png",
+        "caption": "Key Deployment"
+    },
+    {
+        "file": "start-page.png",
+        "caption": "Start Page"
+    },
+    {
+        "file": "tab-overview.png",
+        "caption": "Tab Overview"
+    },
+    {
+        "file": "terminal-settings.png",
+        "caption": "Terminal Settings"
+    }
+];

--- a/docs/screenshots.js
+++ b/docs/screenshots.js
@@ -1,162 +1,49 @@
 (function () {
-    const scheduleLayout = (() => {
+    function createScreenshotFigure(item) {
+        const figure = document.createElement('figure');
+        figure.className = 'screenshot-frame';
 
-        let rafId = null;
-        return (callback) => {
-            if (rafId !== null) return;
-            rafId = requestAnimationFrame(() => {
-                rafId = null;
-                callback();
-            });
-        };
-    })();
+        const img = document.createElement('img');
+        img.loading = 'lazy';
+        img.src = `screenshots/${item.file}`;
+        img.alt = item.caption;
 
-    function getAspectRatio(frame) {
-        const img = frame.querySelector('img');
-        if (!img) {
-            return 1;
-        }
-        if (img.naturalWidth && img.naturalHeight) {
-            return img.naturalWidth / img.naturalHeight;
-        }
-        const rect = img.getBoundingClientRect();
-        if (rect.width && rect.height) {
-            return rect.width / rect.height;
-        }
-        return 1;
+        const caption = document.createElement('figcaption');
+        caption.textContent = item.caption;
+
+        figure.appendChild(img);
+        figure.appendChild(caption);
+
+        return figure;
     }
 
-    function applyRowLayout(row, innerWidth, targetRowHeight, maxRowHeight, gap, isLastRow) {
-        if (!row.length) return;
-        const aspectSum = row.reduce((sum, item) => sum + item.ratio, 0);
-        if (!aspectSum) return;
-        const gapTotal = gap * Math.max(0, row.length - 1);
-        const widthAtTarget = aspectSum * targetRowHeight;
-        let scale = (innerWidth - gapTotal) / widthAtTarget;
-        const maxScale = maxRowHeight / targetRowHeight;
+    function renderScreenshots(gallery, screenshots) {
+        gallery.innerHTML = '';
 
-        if (isLastRow) {
-            scale = Math.min(scale, 1);
-        }
-
-        if (!Number.isFinite(scale) || scale <= 0) {
-            scale = 1;
-        }
-
-        scale = Math.min(scale, maxScale);
-        const rowHeight = Math.max(1, targetRowHeight * scale);
-
-        row.forEach(({ frame, ratio }) => {
-            const width = rowHeight * ratio;
-            frame.style.width = `${width}px`;
-            frame.style.height = `${rowHeight}px`;
-        });
-    }
-
-    function layoutGallery(gallery) {
-        const styles = getComputedStyle(gallery);
-        const targetRowHeight = parseFloat(styles.getPropertyValue('--jg-target-row-height')) || 160;
-        const maxRowHeight = parseFloat(styles.getPropertyValue('--jg-max-row-height')) || targetRowHeight * 1.2;
-        const gap = parseFloat(styles.getPropertyValue('--jg-gap')) || parseFloat(styles.columnGap || styles.gap || 0) || 0;
-        const paddingLeft = parseFloat(styles.paddingLeft) || 0;
-        const paddingRight = parseFloat(styles.paddingRight) || 0;
-        const innerWidth = gallery.clientWidth - paddingLeft - paddingRight;
-        if (innerWidth <= 0) {
+        if (!screenshots.length) {
+            const empty = document.createElement('p');
+            empty.className = 'screenshots-empty-state';
+            empty.textContent = 'Screenshots are on the way.';
+            gallery.appendChild(empty);
             return;
         }
 
-        const frames = Array.from(gallery.querySelectorAll('.screenshot-frame'));
-        if (!frames.length) {
-            return;
-        }
-
-        frames.forEach((frame) => {
-            frame.style.removeProperty('width');
-            frame.style.removeProperty('height');
+        const fragment = document.createDocumentFragment();
+        screenshots.forEach((item) => {
+            fragment.appendChild(createScreenshotFigure(item));
         });
 
-        let row = [];
-        let aspectAccumulator = 0;
-
-        frames.forEach((frame) => {
-            const ratio = getAspectRatio(frame);
-            if (!Number.isFinite(ratio) || ratio <= 0) {
-                return;
-            }
-
-            row.push({ frame, ratio });
-            aspectAccumulator += ratio;
-
-            const expectedWidth = aspectAccumulator * targetRowHeight + gap * Math.max(0, row.length - 1);
-            if (expectedWidth >= innerWidth) {
-                const gapTotal = gap * Math.max(0, row.length - 1);
-                const scale = (innerWidth - gapTotal) / (aspectAccumulator * targetRowHeight);
-                const maxScale = maxRowHeight / targetRowHeight;
-
-                if (scale > maxScale && row.length > 1) {
-                    const lastItem = row.pop();
-                    aspectAccumulator -= lastItem.ratio;
-                    applyRowLayout(row, innerWidth, targetRowHeight, maxRowHeight, gap, false);
-                    row = [lastItem];
-                    aspectAccumulator = lastItem.ratio;
-                } else {
-                    applyRowLayout(row, innerWidth, targetRowHeight, maxRowHeight, gap, false);
-                    row = [];
-                    aspectAccumulator = 0;
-                }
-            }
-        });
-
-        if (row.length) {
-            applyRowLayout(row, innerWidth, targetRowHeight, maxRowHeight, gap, true);
-        }
-    }
-
-    function waitForImages(frames) {
-        return Promise.all(frames.map((frame) => {
-            const img = frame.querySelector('img');
-            if (!img) return Promise.resolve();
-            if (img.complete && img.naturalHeight !== 0) {
-                return Promise.resolve();
-            }
-            return new Promise((resolve) => {
-                img.addEventListener('load', resolve, { once: true });
-                img.addEventListener('error', resolve, { once: true });
-            });
-        }));
-    }
-
-    function initialiseJustifiedGallery(gallery) {
-        if (!gallery) return;
-
-        const runLayout = () => scheduleLayout(() => layoutGallery(gallery));
-
-        const frames = () => Array.from(gallery.querySelectorAll('.screenshot-frame'));
-
-        waitForImages(frames()).then(runLayout);
-
-        window.addEventListener('resize', runLayout);
-
-        if (typeof ResizeObserver !== 'undefined') {
-            const resizeObserver = new ResizeObserver(runLayout);
-
-            resizeObserver.observe(gallery);
-        }
-
-        if (typeof MutationObserver !== 'undefined') {
-            const mutationObserver = new MutationObserver(() => {
-                waitForImages(frames()).then(runLayout);
-
-            });
-            mutationObserver.observe(gallery, { childList: true, subtree: true });
-        }
+        gallery.appendChild(fragment);
     }
 
     document.addEventListener('DOMContentLoaded', () => {
         const gallery = document.querySelector('.screenshots-gallery');
-        if (gallery) {
-            initialiseJustifiedGallery(gallery);
+        if (!gallery) return;
 
-        }
+        const screenshots = Array.isArray(window.screenshotData)
+            ? window.screenshotData
+            : [];
+
+        renderScreenshots(gallery, screenshots);
     });
 })();

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -363,20 +363,16 @@ a:hover {
 
 
 .screenshots-gallery {
-    --jg-target-row-height: 160px;
-    --jg-max-row-height: 190px;
-    --jg-gap: 14px;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: flex-start;
-    gap: var(--jg-gap);
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    grid-auto-rows: 1fr;
+    gap: 18px;
 
     padding: 22px;
     border-radius: 22px;
     border: 1px solid #dfe6f3;
     background: linear-gradient(150deg, #f8fafc 0%, #eef2f7 100%);
     box-shadow: 0 22px 42px rgba(15, 23, 42, 0.08);
-    overflow: hidden;
 }
 
 .screenshots-gallery figure {
@@ -388,11 +384,11 @@ a:hover {
     overflow: hidden;
     border-radius: 16px;
     background: rgba(15, 23, 42, 0.08);
-    transition: transform 0.18s ease, box-shadow 0.18s ease;
-    flex: 0 0 auto;
-    display: block;
-    min-width: 140px;
-
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    aspect-ratio: 16 / 10;
 }
 
 .screenshot-frame::after {
@@ -420,22 +416,22 @@ a:hover {
     width: 100%;
     height: 100%;
     object-fit: cover;
-
     border-radius: 16px;
-    transition: transform 0.25s ease;
+    transition: transform 0.3s ease;
 }
 
 .screenshot-frame:hover img {
-    transform: scale(1.02);
+    transform: scale(1.05);
 }
 
 .screenshot-frame figcaption {
     position: absolute;
     inset: auto 0 0 0;
-    padding: 12px 16px 16px 16px;
+    padding: 14px 18px 18px 18px;
     font-weight: 600;
     font-size: 0.85em;
-    letter-spacing: 0.01em;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
     color: #f8fafc;
     text-align: left;
     background: linear-gradient(180deg, rgba(15, 23, 42, 0), rgba(15, 23, 42, 0.88));
@@ -448,12 +444,19 @@ figcaption {
     font-weight: bold;
 }
 
+.screenshots-empty-state {
+    grid-column: 1 / -1;
+    text-align: center;
+    padding: 40px 20px;
+    color: #475569;
+    font-size: 0.95em;
+    font-style: italic;
+}
+
 @media (max-width: 720px) {
     .screenshots-gallery {
-        --jg-target-row-height: 150px;
-        --jg-max-row-height: 180px;
-        --jg-gap: 12px;
-
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 16px;
         padding: 18px;
         border-radius: 20px;
     }
@@ -461,10 +464,8 @@ figcaption {
 
 @media (max-width: 480px) {
     .screenshots-gallery {
-        --jg-target-row-height: 135px;
-        --jg-max-row-height: 165px;
-        --jg-gap: 10px;
-
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        gap: 14px;
         padding: 14px;
         border-radius: 18px;
     }

--- a/docs/update_screenshots.py
+++ b/docs/update_screenshots.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Utility script to keep the screenshot gallery in sync with the images folder.
+
+The script scans ``docs/screenshots`` for ``.png`` files and writes a JavaScript
+module (``docs/screenshot_data.js``) that exposes a ``window.screenshotData``
+array. Each entry contains the filename and a caption derived from the
+filename. Optional caption overrides can be supplied via
+``docs/screenshot_captions.json``.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+SCREENSHOT_DIR = ROOT / "screenshots"
+OUTPUT_FILE = ROOT / "screenshot_data.js"
+CAPTION_OVERRIDES_FILE = ROOT / "screenshot_captions.json"
+
+
+def _slug_to_caption(name: str) -> str:
+    """Generate a human readable caption from a filename."""
+    stem = Path(name).stem
+    # Split on hyphen/underscore and collapse multiple delimiters.
+    parts = [part for part in re.split(r"[-_]+", stem) if part]
+    if not parts:
+        return stem.title() or name
+    return " ".join(part.capitalize() if part.isupper() else part.title() for part in parts)
+
+
+def load_caption_overrides() -> dict[str, str]:
+    if not CAPTION_OVERRIDES_FILE.exists():
+        return {}
+
+    try:
+        with CAPTION_OVERRIDES_FILE.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Invalid JSON in {CAPTION_OVERRIDES_FILE}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise SystemExit(
+            f"Expected {CAPTION_OVERRIDES_FILE} to contain a JSON object mapping filenames to captions."
+        )
+
+    overrides: dict[str, str] = {}
+    for key, value in data.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise SystemExit(
+                f"Invalid entry in {CAPTION_OVERRIDES_FILE}: both keys and values must be strings."
+            )
+        overrides[key] = value.strip()
+    return overrides
+
+
+def gather_screenshots() -> list[dict[str, str]]:
+    if not SCREENSHOT_DIR.exists():
+        raise SystemExit(f"Screenshot directory {SCREENSHOT_DIR} does not exist.")
+
+    overrides = load_caption_overrides()
+
+    screenshots = []
+    for path in sorted(SCREENSHOT_DIR.glob("*.png")):
+        caption = overrides.get(path.name, _slug_to_caption(path.name))
+        screenshots.append({"file": path.name, "caption": caption})
+
+    return screenshots
+
+
+def write_data_file(screenshots: list[dict[str, str]]) -> None:
+    OUTPUT_FILE.write_text(
+        "window.screenshotData = " + json.dumps(screenshots, indent=4, ensure_ascii=False) + ";\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    screenshots = gather_screenshots()
+    write_data_file(screenshots)
+    print(f"Generated {OUTPUT_FILE.relative_to(ROOT)} with {len(screenshots)} entries.")


### PR DESCRIPTION
## Summary
- replace the hard-coded screenshot markup with a JavaScript-driven gallery that reads from generated data
- restyle the screenshots section to use a responsive CSS grid inspired by the referenced gallery design
- add tooling and documentation so new PNG files automatically appear in the gallery with optional caption overrides

## Testing
- python3 docs/update_screenshots.py

------
https://chatgpt.com/codex/tasks/task_e_68d81742f050832899b7b248cdd4aa50