### PR TITLE
Improve mobile header layout on small screens

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -734,7 +734,29 @@ footer p {
     .nav-mobile {
         display: block;
     }
-    
+
+    .header-content {
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        gap: 12px;
+    }
+
+    .header-icon {
+        width: 48px;
+        height: 48px;
+    }
+
+    .header-content h1 {
+        font-size: 2.2em;
+        height: auto;
+    }
+
+    header p {
+        margin-left: 0;
+        text-align: center;
+    }
+
     .download-buttons {
         grid-template-columns: 1fr;
         gap: 12px;


### PR DESCRIPTION
## Summary
- adjust mobile media query to stack the header content vertically with centered alignment
- shrink the header icon and rescale heading text for improved readability on phones
- reset header paragraph margins for better centering on narrow viewports

## Testing
- Manually verified header layout at 375px viewport width using Playwright screenshot

------
https://chatgpt.com/codex/tasks/task_e_68d83ac7e7848328a93fdacb04dafd09