### PR TITLE
Add GitHub-backed blog page

### DIFF
--- a/docs/blog.html
+++ b/docs/blog.html
@@ -3,10 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>SSH Pilot Reviews and Press Coverage</title>
-    <meta name="description" content="Discover what the community and tech press are saying about SSH Pilot, the user-friendly SSH connection manager.">
+    <title>SSH Pilot Blog</title>
+    <meta name="description" content="Read the latest updates and announcements for SSH Pilot, the user-friendly SSH connection manager.">
     <link rel="stylesheet" href="styles.css">
     <link rel="icon" type="image/svg+xml" href="io.github.mfat.sshpilot.svg">
+    <script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js" defer></script>
+    <script src="blog.js" defer></script>
 </head>
 <body>
     <div class="page">
@@ -49,21 +51,11 @@
         </nav>
 
         <main>
-            <section id="reviews">
-                <h2>Reviews</h2>
-                <p>SSH PILOT has been review by a number of tech blogs.</p>
-
-                <div class="review-card">
-                    <h3>Korben</h3>
-                    <p class="review-summary">French tech blogger Korben highlights SSH Pilot&#39;s intuitive workflow for managing Linux connections and praises its integrated terminal experience.</p>
-                    <a class="review-link" href="https://korben.info/ssh-pilot-gestionnaire-connexions-linux.html" target="_blank" rel="noopener">Read the Korben article</a>
-                </div>
-
-                <div class="review-card">
-                    <h3>Linux und Ich</h3>
-                    <p class="review-summary">Linux und Ich presents SSH Pilot as a modern alternative to PuTTY and SecureCRT, emphasizing the streamlined interface and smart management tools.</p>
-                    <a class="review-link" href="https://linuxundich.de/gnu-linux/sshpilot-linux-alternative-putty-securecrt/" target="_blank" rel="noopener">Read the Linux und Ich review</a>
-                </div>
+            <section id="blog">
+                <h2>Blog</h2>
+                <p class="blog-intro">Updates, release notes, and development insights from the SSH Pilot project.</p>
+                <p id="blog-status" class="blog-status">Loading posts...</p>
+                <div id="blog-posts" class="blog-list" aria-live="polite"></div>
             </section>
         </main>
 
@@ -105,41 +97,5 @@
             </div>
         </footer>
     </div>
-
-    <script>
-    document.addEventListener('DOMContentLoaded', function() {
-        const hamburger = document.getElementById('hamburger');
-        const navMenu = document.getElementById('nav-menu');
-
-        hamburger.addEventListener('click', function() {
-            hamburger.classList.toggle('active');
-            navMenu.classList.toggle('active');
-        });
-
-        const navLinks = navMenu.querySelectorAll('a');
-        navLinks.forEach(link => {
-            link.addEventListener('click', function() {
-                hamburger.classList.remove('active');
-                navMenu.classList.remove('active');
-            });
-        });
-    });
-
-    (async () => {
-        const repo = "mfat/sshpilot";
-        try {
-            const r = await fetch(`https://api.github.com/repos/${repo}`);
-            const data = await r.json();
-            const starsCount = data.stargazers_count;
-
-            const starsElement = document.getElementById("github-stars");
-            if (starsElement) {
-                starsElement.textContent = `⭐ ${starsCount.toLocaleString()}`;
-            }
-        } catch (error) {
-            console.error('Failed to fetch GitHub stars:', error);
-        }
-    })();
-    </script>
 </body>
 </html>

--- a/docs/blog.js
+++ b/docs/blog.js
@@ -1,0 +1,161 @@
+(function () {
+    const repo = "mfat/sshpilot";
+    const issuesEndpoint = `https://api.github.com/repos/${repo}/issues?labels=blog&state=all&per_page=20&sort=created&direction=desc`;
+
+    function setupNavigation() {
+        const hamburger = document.getElementById('hamburger');
+        const navMenu = document.getElementById('nav-menu');
+
+        if (!hamburger || !navMenu) {
+            return;
+        }
+
+        hamburger.addEventListener('click', function () {
+            hamburger.classList.toggle('active');
+            navMenu.classList.toggle('active');
+        });
+
+        const navLinks = navMenu.querySelectorAll('a');
+        navLinks.forEach(link => {
+            link.addEventListener('click', function () {
+                hamburger.classList.remove('active');
+                navMenu.classList.remove('active');
+            });
+        });
+    }
+
+    async function updateGitHubStars() {
+        const starsElement = document.getElementById('github-stars');
+        if (!starsElement) {
+            return;
+        }
+
+        try {
+            const response = await fetch(`https://api.github.com/repos/${repo}`);
+            if (!response.ok) {
+                throw new Error(`GitHub API responded with ${response.status}`);
+            }
+            const data = await response.json();
+            if (typeof data.stargazers_count === 'number') {
+                starsElement.textContent = `⭐ ${data.stargazers_count.toLocaleString()}`;
+            }
+        } catch (error) {
+            console.error('Failed to fetch GitHub stars:', error);
+        }
+    }
+
+    function formatDate(dateString) {
+        const date = new Date(dateString);
+        if (Number.isNaN(date.getTime())) {
+            return '';
+        }
+
+        return date.toLocaleDateString(undefined, {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric'
+        });
+    }
+
+    function renderPost(issue) {
+        const article = document.createElement('article');
+        article.className = 'blog-post';
+
+        const title = document.createElement('h3');
+        const titleLink = document.createElement('a');
+        titleLink.href = issue.html_url;
+        titleLink.target = '_blank';
+        titleLink.rel = 'noopener';
+        titleLink.textContent = issue.title;
+        title.appendChild(titleLink);
+
+        const meta = document.createElement('p');
+        meta.className = 'blog-meta';
+        const author = issue.user && issue.user.login ? issue.user.login : 'SSH Pilot Team';
+        const createdAt = formatDate(issue.created_at);
+        const updatedAt = issue.updated_at && issue.updated_at !== issue.created_at
+            ? formatDate(issue.updated_at)
+            : null;
+
+        let metaText = createdAt ? `Published on ${createdAt}` : 'Published';
+        metaText += ` by ${author}`;
+        if (updatedAt && updatedAt !== createdAt) {
+            metaText += ` · Updated ${updatedAt}`;
+        }
+        meta.textContent = metaText;
+
+        const body = document.createElement('div');
+        body.className = 'blog-content';
+        const markdown = issue.body || '';
+        if (window.marked && typeof window.marked.parse === 'function') {
+            body.innerHTML = window.marked.parse(markdown);
+        } else {
+            body.innerHTML = markdown.replace(/\n/g, '<br>');
+        }
+
+        const discussion = document.createElement('p');
+        discussion.className = 'blog-discussion';
+        const discussionLink = document.createElement('a');
+        discussionLink.href = issue.html_url;
+        discussionLink.target = '_blank';
+        discussionLink.rel = 'noopener';
+        discussionLink.textContent = 'Join the discussion on GitHub';
+        discussion.appendChild(discussionLink);
+
+        article.appendChild(title);
+        article.appendChild(meta);
+        article.appendChild(body);
+        article.appendChild(discussion);
+
+        return article;
+    }
+
+    async function loadPosts() {
+        const postsContainer = document.getElementById('blog-posts');
+        const statusElement = document.getElementById('blog-status');
+
+        if (!postsContainer || !statusElement) {
+            return;
+        }
+
+        try {
+            statusElement.textContent = 'Loading posts...';
+            statusElement.classList.remove('error');
+            const response = await fetch(issuesEndpoint, {
+                headers: {
+                    Accept: 'application/vnd.github+json'
+                }
+            });
+
+            if (!response.ok) {
+                throw new Error(`GitHub API responded with ${response.status}`);
+            }
+
+            const issues = await response.json();
+            const posts = (Array.isArray(issues) ? issues : []).filter(issue => !issue.pull_request);
+
+            postsContainer.innerHTML = '';
+
+            if (!posts.length) {
+                statusElement.textContent = 'No blog posts available yet. Check back soon!';
+                return;
+            }
+
+            statusElement.textContent = '';
+
+            posts.forEach(issue => {
+                postsContainer.appendChild(renderPost(issue));
+            });
+        } catch (error) {
+            console.error('Failed to load blog posts:', error);
+            statusElement.textContent = 'We were unable to load the blog posts from GitHub at this time. Please try again later.';
+            statusElement.classList.add('error');
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        setupNavigation();
+        updateGitHubStars();
+        loadPosts();
+    });
+})();

--- a/docs/index.html
+++ b/docs/index.html
@@ -56,6 +56,7 @@
                     <a href="#download">Download</a> |
                     <a href="#features">Features</a> |
                     <a href="https://github.com/mfat/sshpilot/wiki" target="_blank">Documentation</a> |
+                    <a href="blog.html">Blog</a> |
                     <a href="reviews.html">Reviews</a> |
                     <a href="https://github.com/mfat/sshpilot" target="_blank">GitHub</a>
                 </div>
@@ -70,6 +71,7 @@
                         <a href="#download">Download</a>
                         <a href="#features">Features</a>
                         <a href="https://github.com/mfat/sshpilot/wiki" target="_blank">Documentation</a>
+                        <a href="blog.html">Blog</a>
                         <a href="reviews.html">Reviews</a>
                         <a href="https://github.com/mfat/sshpilot" target="_blank">GitHub</a>
                     </div>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -273,6 +273,19 @@ li {
     border: 1px solid #e2e2e2;
 }
 
+.blog-intro {
+    margin-bottom: 15px;
+}
+
+.blog-status {
+    margin: 15px 0;
+    color: #555;
+}
+
+.blog-status.error {
+    color: #b00020;
+}
+
 .blog-list {
     display: grid;
     gap: 20px;
@@ -298,6 +311,28 @@ li {
 
 .blog-link {
     font-weight: 600;
+}
+
+.blog-content {
+    line-height: 1.7;
+}
+
+.blog-content pre {
+    background: #f6f8fa;
+    padding: 12px;
+    border-radius: 8px;
+    overflow-x: auto;
+    font-size: 0.95em;
+}
+
+.blog-content code {
+    background: #f6f8fa;
+    padding: 2px 4px;
+    border-radius: 4px;
+}
+
+.blog-discussion {
+    margin-top: 20px;
 }
 
 /* Reviews section styling */


### PR DESCRIPTION
## Summary
- add a dedicated blog page that pulls posts from GitHub issues tagged with the blog label
- create styling and scripting to render markdown content and keep navigation consistent
- link to the new blog from existing navigation elements

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd0d988c1c83288ddbd4eddecb4738