### PR TITLE
fix: slight margins on blog/reviews sections

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -289,7 +289,7 @@ li {
     color: #333;
     padding: 25px;
     border-radius: 15px;
-    margin: 30px 0;
+    margin: 30px 10px;
     border: 1px solid #e2e2e2;
 }
 
@@ -361,7 +361,7 @@ li {
     color: #1f2a44;
     padding: 25px;
     border-radius: 15px;
-    margin: 30px 0;
+    margin: 30px 10px;
     border: 1px solid #d0ddff;
 }
 


### PR DESCRIPTION
Gives the sections just a bit of breathing room, since rounded borders right on the side with no horizontal margin looks a tad off

| Before | After |
|--------|--------|
| <img width="2145" height="2305" alt="image" src="https://github.com/user-attachments/assets/37db94cb-b8e5-49b1-8468-a6c74f631ed8" /> | <img width="2145" height="2305" alt="image" src="https://github.com/user-attachments/assets/e671f394-53a5-462f-b540-9314a9d5b5e8" /> |
| <img width="2145" height="2305" alt="image" src="https://github.com/user-attachments/assets/83d11640-8aa6-4844-b42b-a515e74f8533" /> | <img width="2145" height="2305" alt="image" src="https://github.com/user-attachments/assets/5fd72f91-44a6-4b02-a784-59e3deed6570" /> | 